### PR TITLE
refactor: 단일 책임 원칙에 따른 서비스 계층 분리, API 계층의 유효성 검사 및 예외 처리 강화

### DIFF
--- a/src/main/java/com/wook/interview_ai/dto/ResumeRequestDto.java
+++ b/src/main/java/com/wook/interview_ai/dto/ResumeRequestDto.java
@@ -1,6 +1,7 @@
 package com.wook.interview_ai.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,13 +13,16 @@ import lombok.Setter;
 public class ResumeRequestDto {
     /** 경력 요약 */
     @NotBlank(message = "경력 요약은 필수 입력 항목입니다.")
+    @Size(max = 1000, message = "경력 요약은 1000자를 초과할 수 없습니다.")
     private String career;
 
     /** 수행 직무 */
     @NotBlank(message = "수행 직무는 필수 입력 항목입니다.")
+    @Size(max = 1000, message = "수행 직무는 1000자를 초과할 수 없습니다.")
     private String job;
 
     /** 보유 기술 스킬 */
     @NotBlank(message = "보유 기술 스킬은 필수 입력 항목입니다.")
+    @Size(max = 500, message = "보유 기술 스킬은 500자를 초과할 수 없습니다.")
     private String skill;
 }

--- a/src/main/java/com/wook/interview_ai/service/CareerCoachService.java
+++ b/src/main/java/com/wook/interview_ai/service/CareerCoachService.java
@@ -12,75 +12,24 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 
+
 /**
- * AI 커리어 코칭의 핵심 비즈니스 로직을 처리하는 서비스입니다.
+ * 커리어 코칭 비즈니스 로직의 전체 흐름을 제어(오케스트레이션)하는 서비스입니다.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CareerCoachService {
 
-    private final Client genaiClient;
-    private final ObjectMapper objectMapper;
-
-    @Value("${gemini.prompt}")
-    private String promptTemplate;
+    private final PromptService promptService;
+    private final GeminiService geminiService;
 
     public CoachResponseDto generateCoaching(ResumeRequestDto requestDto) {
-        // 1. 사용자 이력서 정보를 하나의 텍스트로 결합
-        String resumeText = String.format(
-                "경력 요약: %s\n수행 직무: %s\n보유 기술: %s",
-                requestDto.getCareer(),
-                requestDto.getJob(),
-                requestDto.getSkill()
-        );
-
-        // 2. 프롬프트 템플릿과 이력서 정보를 조합하여 최종 프롬프트 완성
-        String finalPrompt = String.format(promptTemplate, resumeText);
+        // 1. PromptService를 통해 AI에게 보낼 프롬프트를 생성합니다.
+        String finalPrompt = promptService.createCoachingPrompt(requestDto);
         log.info("Gemini AI에게 전송할 최종 프롬프트:\n{}", finalPrompt);
 
-        try {
-            /// 3. AI 모델에 요청 전송 및 응답 수신
-            GenerateContentResponse response = genaiClient.models.generateContent(
-                    "gemini-2.5-flash", // 요청하신 모델 이름으로 변경
-                    finalPrompt,
-                    null
-            );
-            String rawResponse = response.text();
-            log.info("Gemini AI로부터 받은 원본 응답:\n{}", rawResponse);
-
-            // 4. AI 응답에서 순수 JSON만 추출
-            String jsonResponse = extractJson(rawResponse);
-
-            log.info("추출된 순수 JSON 응답:\n{}", jsonResponse);
-
-            // 5. JSON 응답을 DTO 객체로 변환하여 반환
-            return objectMapper.readValue(jsonResponse, CoachResponseDto.class);
-
-        } catch (IOException e) {
-            log.error("AI 응답 생성 또는 JSON 파싱에 실패했습니다.", e);
-            throw new RuntimeException("AI 응답을 처리하는 중 오류가 발생했습니다.");
-        }
-    }
-
-    /**
-     * AI가 생성한 원본 문자열에서 JSON 부분만 추출합니다.
-     * (e.g., Markdown 코드 블록 제거)
-     * @param rawResponse AI가 보낸 원본 문자열
-     * @return 순수 JSON 형식의 문자열
-     */
-    private String extractJson(String rawResponse) {
-        // 첫 '{' 문자의 위치를 찾습니다.
-        int startIndex = rawResponse.indexOf('{');
-        // 마지막 '}' 문자의 위치를 찾습니다.
-        int endIndex = rawResponse.lastIndexOf('}');
-
-        // '{'와 '}'를 모두 찾았고, 순서가 올바르다면 그 사이의 문자열을 반환합니다.
-        if (startIndex != -1 && endIndex != -1 && endIndex > startIndex) {
-            return rawResponse.substring(startIndex, endIndex + 1).trim();
-        }
-
-        // JSON 형식을 찾지 못했다면 원본 문자열을 그대로 반환하여 파싱 오류를 유발시킵니다.
-        return rawResponse;
+        // 2. GeminiService를 통해 AI 응답을 받아옵니다.
+        return geminiService.generateCoaching(finalPrompt);
     }
 }

--- a/src/main/java/com/wook/interview_ai/service/GeminiService.java
+++ b/src/main/java/com/wook/interview_ai/service/GeminiService.java
@@ -1,0 +1,68 @@
+package com.wook.interview_ai.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+import com.wook.interview_ai.dto.CoachResponseDto;
+import com.wook.interview_ai.exception.LLMProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+/**
+ * Gemini AI 모델과의 통신 및 응답 처리를 전담하는 서비스입니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiService {
+
+    private final Client genaiClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 완성된 프롬프트를 AI 모델에 전달하고, 응답을 DTO로 파싱하여 반환합니다.
+     * @param finalPrompt AI 모델에 전달할 최종 프롬프트
+     * @return AI가 생성한 코칭 결과 DTO
+     */
+    public CoachResponseDto generateCoaching(String finalPrompt) {
+        try {
+            // 1. AI 모델에 요청 전송 및 응답 수신
+            GenerateContentResponse response = genaiClient.models.generateContent(
+                    "gemini-2.5-flash-lite", // 사용할 모델 이름
+                    finalPrompt,
+                    null
+            );
+            String rawResponse = response.text();
+            log.info("Gemini AI로부터 받은 원본 응답:\n{}", rawResponse);
+
+            // 2. AI 응답에서 순수 JSON만 추출
+            String jsonResponse = extractJson(rawResponse);
+            log.info("추출된 순수 JSON 응답:\n{}", jsonResponse);
+
+            // 3. JSON 응답을 DTO 객체로 변환하여 반환
+            return objectMapper.readValue(jsonResponse, CoachResponseDto.class);
+
+        } catch (IOException e) {
+            log.error("AI 응답 생성 또는 JSON 파싱에 실패했습니다.", e);
+            throw new LLMProcessingException("AI 응답을 처리하는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * AI가 생성한 원본 문자열에서 JSON 부분만 추출합니다.
+     * @param rawResponse AI가 보낸 원본 문자열
+     * @return 순수 JSON 형식의 문자열
+     */
+    private String extractJson(String rawResponse) {
+        int startIndex = rawResponse.indexOf('{');
+        int endIndex = rawResponse.lastIndexOf('}');
+
+        if (startIndex != -1 && endIndex != -1 && endIndex > startIndex) {
+            return rawResponse.substring(startIndex, endIndex + 1).trim();
+        }
+        return rawResponse;
+    }
+}

--- a/src/main/java/com/wook/interview_ai/service/PromptService.java
+++ b/src/main/java/com/wook/interview_ai/service/PromptService.java
@@ -1,0 +1,34 @@
+package com.wook.interview_ai.service;
+
+import com.wook.interview_ai.config.GeminiProperties;
+import com.wook.interview_ai.dto.ResumeRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * AI 모델에 전달할 프롬프트를 생성하는 책임을 담당하는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PromptService {
+
+    private final GeminiProperties geminiProperties;
+
+    /**
+     * 사용자 이력서 정보와 템플릿을 조합하여 최종 프롬프트를 생성합니다.
+     * @param requestDto 사용자 이력서 정보
+     * @return AI 모델에 전달할 완성된 프롬프트 문자열
+     */
+    public String createCoachingPrompt(ResumeRequestDto requestDto) {
+        // 1. 사용자 이력서 정보를 하나의 텍스트로 결합
+        String resumeText = String.format(
+                "경력 요약: %s\n수행 직무: %s\n보유 기술: %s",
+                requestDto.getCareer(),
+                requestDto.getJob(),
+                requestDto.getSkill()
+        );
+
+        // 2. 프롬프트 템플릿과 이력서 정보를 조합하여 최종 프롬프트 완성
+        return String.format(geminiProperties.getPrompt(), resumeText);
+    }
+}


### PR DESCRIPTION
1. 기존의 거대한 역할을 담당하던 CareerCoachService를 역할에 따라 분리하여 코드의 유지보수성과 확장성을 개선했습니다
2. API의 견고함을 높이기 위해 DTO의 입력값 검증과 예외 처리 로직을 개선했습니다